### PR TITLE
Rewrite ⎕FIO functions

### DIFF
--- a/test.apl
+++ b/test.apl
@@ -1,9 +1,10 @@
 #!/usr/bin/env apl --script
+)COPY 5 FILE_IO.apl
 
 ⍝ Clear logfile with given filename.
 ∇test∆clear_log filename;handle;_
-  handle←'w' ⎕FIO[3] filename
-  _←⎕FIO[4] handle
+  handle←'w' FIO∆fopen filename
+  _←FIO∆fclose handle
 ∇
 
 ⍝ )COPY file relative to current directory.
@@ -35,15 +36,15 @@
 
 ⍝ Return current directory as a string.
 ∇pwd←test¯pwd
-  pwd←⎕FIO 30
+  pwd←FIO∆getcwd
 ∇
 
 ⍝ Read a UTF-8 file into a Unicode character vector.
 ∇unicode←test¯read_unicode filename
-  unicode←19⎕CR ⎕FIO[26] filename
+  unicode←19⎕CR FIO∆read_file filename
 ∇
 
 ⍝ Write string to stderr.
 ∇test¯warn string;_
-  _←'%s' string ⎕FIO[22] 2
+  _←FIO∆fprintf_stderr '%s' string
 ∇

--- a/test.apl
+++ b/test.apl
@@ -14,7 +14,7 @@
 
 ⍝ Write logfile with given filename to stderr as UTF-8.
 ∇test∆show_log filename;cr
-  cr←⎕ucs 10
+  cr←⎕UCS 10
   test¯warn cr,'***** TEST LOG *****',cr,cr
   test¯warn test¯read_unicode filename
 ∇


### PR DESCRIPTION
GNU APL's native file handling functions are of the form `⎕FIO[number]`, which isn't very readable, and 1.7 changed its semantics anyway (see #18). Fortunately, GNU APL also comes with a library that wraps the various `⎕FIO` functions with human-readable names, so we should use that.