### PR TITLE
Interleaving STDOUT and STDERR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_install:
 
 script:
   - bin/configlet lint .
-  - docker run apl 'bin/run-all-tests'
+  - docker run apl 'bin/run-all-tests 2>&1'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_install:
 
 script:
   - bin/configlet lint .
-  - docker run apl 'bin/run-all-tests 2>&1'
+  - docker run -a stderr apl 'bin/run-all-tests'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_install:
 
 script:
   - bin/configlet lint .
-  - docker run apl /bin/bash -c bin/run-all-tests '2>&1'
+  - docker run -a stdout -a stderr apl bin/run-all-tests 2>&1

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_install:
 
 script:
   - bin/configlet lint .
-  - docker run apl '/bin/bash -c bin/run-all-tests 2>&1'
+  - docker run apl /bin/bash -c bin/run-all-tests 2>&1

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_install:
 
 script:
   - bin/configlet lint .
-  - docker run apl /bin/bash -c bin/run-all-tests 2>&1
+  - docker run apl /bin/bash -c bin/run-all-tests '2>&1'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_install:
 
 script:
   - bin/configlet lint .
-  - docker run -a stderr apl 'bin/run-all-tests'
+  - docker run apl '/bin/bash -c bin/run-all-tests 2>&1'


### PR DESCRIPTION
This is an experimental branch where I'm trying to fix some of the issues in the test log. The issue is as follows: since starting to use Docker for our build process (see #21), test output appears in a strange order. This is because GNU APL's testrunner uses STDERR for the testcase lines representing user input, and STDOUT for interpreter output. Unfortunately, due to buffering issues, Docker has no way of ensuring that all that is interleaved in the right order (see https://github.com/moby/moby/issues/26986 and https://github.com/moby/moby/issues/31706).

If anyone has some good ideas for how to deal with this, I welcome contributions!