### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "53edd374-54a1-40d3-bf42-185e29153e11",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing GNU APL locally",
+      "blurb": "Learn how to install GNU APL locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "51b7567c-a533-4ec8-8871-295e2ec956a7",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn GNU APL",
+      "blurb": "An overview of how to get started from scratch with GNU APL"
+    },
+    {
+      "uuid": "965fd33b-8c64-4357-996e-f5aad5d165cc",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the GNU APL track",
+      "blurb": "Learn how to test your GNU APL exercises on Exercism"
+    },
+    {
+      "uuid": "6b0a415f-f68e-411e-8f11-777e0e68c1a6",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful GNU APL resources",
+      "blurb": "A collection of useful resources to help you master GNU APL"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
