### PR TITLE
🤖 Sync exercise files keys based on file path patterns

### DIFF
--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "difference-of-squares.apl"
+    ],
+    "test": [
+      "difference-of-squares.tc"
+    ],
+    "example": [
+      ".meta/difference-of-squares-example.apl"
+    ]
   },
   "source": "Problem 6 at Project Euler",
   "source_url": "http://projecteuler.net/problem=6"

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Calculate the Hamming difference between two DNA strands.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "hamming.apl"
+    ],
+    "test": [
+      "hamming.tc"
+    ],
+    "example": [
+      ".meta/hamming-example.apl"
+    ]
   },
   "source": "The Calculating Point Mutations problem at Rosalind",
   "source_url": "http://rosalind.info/problems/hamm/"

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "hello-world.apl"
+    ],
+    "test": [
+      "hello-world.tc"
+    ],
+    "example": [
+      ".meta/hello-world-example.apl"
+    ]
   },
   "source": "This is an exercise to introduce users to using Exercism",
   "source_url": "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program"

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a year, report if it is a leap year.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "leap.apl"
+    ],
+    "test": [
+      "leap.tc"
+    ],
+    "example": [
+      ".meta/leap-example.apl"
+    ]
   },
   "source": "JavaRanch Cattle Drive, exercise 3",
   "source_url": "http://www.javaranch.com/leap.jsp"

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Determine if a sentence is a pangram.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "pangram.apl"
+    ],
+    "test": [
+      "pangram.tc"
+    ],
+    "example": [
+      ".meta/pangram-example.apl"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Pangram"

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Convert a number to a string, the content of which depends on the number's factors.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "raindrops.apl"
+    ],
+    "test": [
+      "raindrops.tc"
+    ],
+    "example": [
+      ".meta/raindrops-example.apl"
+    ]
   },
   "source": "A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division.",
   "source_url": "https://en.wikipedia.org/wiki/Fizz_buzz"

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "rna-transcription.apl"
+    ],
+    "test": [
+      "rna-transcription.tc"
+    ],
+    "example": [
+      ".meta/rna-transcription-example.apl"
+    ]
   },
   "source": "Hyperphysics",
   "source_url": "http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html"


### PR DESCRIPTION
To help tracks define the files in the exercise's `.meta/config.json` file, we've added support for defining these file patterns in the track's `config.json` file. See [this PR](https://github.com/exercism/docs/pull/58).

This PR updates the file paths defined in the `files` property of each exercise's `.meta/config.json` file according to the file patterns defined in the track's `config.json` file.

We only update a file path in the `.meta/config.json` file if:

- The file path pattern is a non-empty array in the `config.json` file
- The file path pattern is either not set or an empty array in the `.meta/config.json` file

This means that exercises that had already defined files in the `.meta/config.json` won't be touched in this PR.

Note that this PR is just an easy way for tracks to populate the files in the `.meta/config.json` files. Tracks are completely free to add/change/remove the files in their `.meta/config.json` files.

In the future, we'll update `configlet` to include this functionality. If you'd like me to re-run the script because changes have been made, feel free to ping me on Slack (@erikschierboom).

## Tracking

https://github.com/exercism/v3-launch/issues/20

