### PR TITLE
Allow shell override of APL binary path

### DIFF
--- a/bin/run-all-tests
+++ b/bin/run-all-tests
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 STATUS=0
-APL=/usr/bin/apl
+APL=${APL:-"/usr/bin/apl"}
 APL_OPTS='--silent --Color'
 TMP=tmp
 


### PR DESCRIPTION
If running locally and one's GNU APL installation is somewhere other than /usr/bin/, this change allows overriding the location, e.g.

`$ APL=/usr/local/bin bin/run-run-all-tests`